### PR TITLE
Add level flag when downloading bites

### DIFF
--- a/src/eatlocal/__main__.py
+++ b/src/eatlocal/__main__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import typer
 from rich import print
 from rich.status import Status
+from typing import Optional
 
 from . import __version__
 from .constants import EATLOCAL_HOME
@@ -71,10 +72,16 @@ def download(
         is_flag=True,
         help="Overwrite bite directory with a fresh version.",
     ),
+    level: Optional[str] = typer.Option(
+        None,
+        "--level",
+        "-l",
+        help="Filter bites by difficulty level.",
+    ),
 ) -> None:
     """Download and extract bite code from pybitesplatform.com."""
     config = load_config(EATLOCAL_HOME / ".env")
-    bite = choose_bite(clear)
+    bite = choose_bite(clear, level=level.lower())
     with Status("Downloading bite..."):
         bite.platform_content = download_bite(bite, config)
         if bite.platform_content is None:

--- a/src/eatlocal/__main__.py
+++ b/src/eatlocal/__main__.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import typer
 from rich import print
 from rich.status import Status
-from typing import Optional
 
 from . import __version__
 from .constants import EATLOCAL_HOME
@@ -72,7 +71,7 @@ def download(
         is_flag=True,
         help="Overwrite bite directory with a fresh version.",
     ),
-    level: Optional[str] = typer.Option(
+    level: str | None = typer.Option(
         None,
         "--level",
         "-l",

--- a/src/eatlocal/__main__.py
+++ b/src/eatlocal/__main__.py
@@ -81,7 +81,7 @@ def download(
 ) -> None:
     """Download and extract bite code from pybitesplatform.com."""
     config = load_config(EATLOCAL_HOME / ".env")
-    bite = choose_bite(clear, level=level.lower())
+    bite = choose_bite(clear, level=level)
     with Status("Downloading bite..."):
         bite.platform_content = download_bite(bite, config)
         if bite.platform_content is None:

--- a/src/eatlocal/eatlocal.py
+++ b/src/eatlocal/eatlocal.py
@@ -314,7 +314,7 @@ def choose_bite(clear: bool = False, level: Optional[str] = None) -> Bite:
             sys.exit()
         if level:
             # Filter bites by level (case-insensitive)
-            if level not in VALID_LEVELS:
+            if level.lower() not in VALID_LEVELS:
                 console.print(
                     f":warning: Invalid level: {level}.",
                     style=ConsoleStyle.WARNING.value,
@@ -327,7 +327,7 @@ def choose_bite(clear: bool = False, level: Optional[str] = None) -> Bite:
             bites = {
                 bite["title"]: bite["slug"]
                 for bite in r.json()
-                if bite["level"].lower() == level
+                if bite["level"].lower() == level.lower()
             }
         else:
             # Display bites of all levels.

--- a/src/eatlocal/eatlocal.py
+++ b/src/eatlocal/eatlocal.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from os import environ, makedirs
 from pathlib import Path
-from typing import Optional, FrozenSet
+from typing import FrozenSet
 
 import install_playwright
 import requests
@@ -291,7 +291,7 @@ def choose_local_bite(config: dict) -> Bite:
     return Bite(bite, bites[bite])
 
 
-def choose_bite(clear: bool = False, level: Optional[str] = None) -> Bite:
+def choose_bite(clear: bool = False, *, level: str | None = None) -> Bite:
     """Choose which level of bite will be downloaded.
 
     Returns:
@@ -312,7 +312,7 @@ def choose_bite(clear: bool = False, level: Optional[str] = None) -> Bite:
                 style=ConsoleStyle.SUGGESTION.value,
             )
             sys.exit()
-        if level:
+        if level is not None:
             # Filter bites by level (case-insensitive)
             if level.lower() not in VALID_LEVELS:
                 console.print(


### PR DESCRIPTION
Adds `level` flag to download which level of bites is to be downloaded.

```Python
# Show all bites (original behavior)
$ eatlocal download

# Show only beginner bites
$ eatlocal download --level Beginner

# Show only intermediate bites
$ eatlocal download --level Intermediate

# Show only advanced bites
$ eatlocal download --level Advanced
```

Edge case that I can think of right now 

1. Level is not valid so added an exception for it 

```Python
$ eatlocal download --level advance
⚠ Invalid level: advance.
Valid levels are: advanced, intro, intermediate, newbie, beginner.
```
