### PR TITLE
Add level column to enrich the table of eatlocal download

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,23 @@ eatlocal init
 Download bites:
 
 ```bash
+# Show all bites
 eatlocal download
+
+# Show only newbie bites
+eatlocal download --level newbie
+
+# Show only intro bites
+eatlocal download --level intro
+
+# Show only beginner bites
+eatlocal download --level Beginner
+
+# Show only intermediate bites
+eatlocal download --level Intermediate
+
+# Show only advanced bites
+eatlocal download --level Advanced
 ```
 
 If you want to force a re-download of a given bite use the `--force` flag. This will overwrite the bite directory.

--- a/src/eatlocal/eatlocal.py
+++ b/src/eatlocal/eatlocal.py
@@ -47,6 +47,11 @@ VALID_LEVELS: FrozenSet[str] = frozenset(
     ["newbie", "intro", "beginner", "intermediate", "advanced"]
 )
 
+# ANSI escape code for green color
+GREEN = "\033[32m"
+# Reset color back to default
+RESET = "\033[0m"
+
 
 @dataclass
 class Bite:
@@ -295,6 +300,35 @@ def choose_local_bite(config: dict) -> Bite:
     return Bite(bite, bites[bite])
 
 
+def _format_bite_key(title: str, level: str, padding: int) -> str:
+    """Format the bite key with for display.
+    Returns:
+        A formatted string with the bite title and level.
+    """
+    return f"{title:<{padding}}{GREEN}{level.capitalize():>40}{RESET}"
+
+
+def _unformat_bite_key(formatted_key: str) -> str:
+    """Unformat a bite key to get the original title.
+
+    Args:
+        formatted_key: The formatted string containing title and level.
+
+    Returns:
+        The original title string.
+    """
+    # Remove the ANSI color codes
+    uncolored = formatted_key.replace(GREEN, "").replace(RESET, "")
+
+    # Split into title and level parts and get just the title
+    # The title is everything before the right-aligned level (40 spaces)
+    title = uncolored.rstrip()  # Remove trailing spaces
+    # Split on multiple spaces to separate title from level
+    parts = title.split()
+    # Return everything except the last word (which is the level)
+    return " ".join(parts[:-1])
+
+
 def choose_bite(clear: bool = False, *, level: str | None = None) -> Bite:
     """Choose which level of bite will be downloaded.
 
@@ -316,6 +350,7 @@ def choose_bite(clear: bool = False, *, level: str | None = None) -> Bite:
                 style=ConsoleStyle.SUGGESTION.value,
             )
             sys.exit()
+        bites_data = r.json()
         if level is not None:
             # Filter bites by level (case-insensitive)
             if level.lower() not in VALID_LEVELS:
@@ -330,16 +365,43 @@ def choose_bite(clear: bool = False, *, level: str | None = None) -> Bite:
                 sys.exit()
             bites = {
                 bite["title"]: bite["slug"]
-                for bite in r.json()
+                for bite in bites_data
                 if bite["level"].lower() == level.lower()
             }
         else:
             # Display bites of all levels.
-            bites = {bite["title"]: bite["slug"] for bite in r.json()}
-    bite_to_download = iterfzf(bites, multi=False)
+            bites = {}
+            max_title_length = 0
+            # Store original titles and slug for Bite object.
+            bite_mapping = {}
+
+            for bite in bites_data:
+                title_length = len(bite["title"])
+                max_title_length = max(max_title_length, title_length)
+
+                bites[bite["title"]] = (bite["level"], bite["slug"])
+                bite_mapping[bite["title"]] = bite["slug"]
+
+            # bite levels will always be aligned on the right side, with some consistent spacing
+            # between the title and level.
+            padding = max_title_length + 10
+            formatted_bites = {
+                _format_bite_key(title, level, padding): slug
+                for title, (level, slug) in bites.items()
+            }
+
+    choices = bites if level is not None else formatted_bites
+    bite_to_download = iterfzf(choices, multi=False, ansi=True)
+
     if bite_to_download is None:
         sys.exit()
-    slug = bites[bite_to_download]
+
+    slug = (
+        bites[bite_to_download]
+        if level is not None
+        else bite_mapping[_unformat_bite_key(bite_to_download)]
+    )
+
     return Bite(bite_to_download, slug)
 
 

--- a/src/eatlocal/eatlocal.py
+++ b/src/eatlocal/eatlocal.py
@@ -317,15 +317,9 @@ def _unformat_bite_key(formatted_key: str) -> str:
     Returns:
         The original title string.
     """
-    # Remove the ANSI color codes
     uncolored = formatted_key.replace(GREEN, "").replace(RESET, "")
-
-    # Split into title and level parts and get just the title
-    # The title is everything before the right-aligned level (40 spaces)
-    title = uncolored.rstrip()  # Remove trailing spaces
-    # Split on multiple spaces to separate title from level
+    title = uncolored.rstrip()
     parts = title.split()
-    # Return everything except the last word (which is the level)
     return " ".join(parts[:-1])
 
 
@@ -352,7 +346,6 @@ def choose_bite(clear: bool = False, *, level: str | None = None) -> Bite:
             sys.exit()
         bites_data = r.json()
         if level is not None:
-            # Filter bites by level (case-insensitive)
             if level.lower() not in VALID_LEVELS:
                 console.print(
                     f":warning: Invalid level: {level}.",
@@ -369,10 +362,8 @@ def choose_bite(clear: bool = False, *, level: str | None = None) -> Bite:
                 if bite["level"].lower() == level.lower()
             }
         else:
-            # Display bites of all levels.
             bites = {}
             max_title_length = 0
-            # Store original titles and slug for Bite object.
             bite_mapping = {}
 
             for bite in bites_data:
@@ -381,9 +372,6 @@ def choose_bite(clear: bool = False, *, level: str | None = None) -> Bite:
 
                 bites[bite["title"]] = (bite["level"], bite["slug"])
                 bite_mapping[bite["title"]] = bite["slug"]
-
-            # bite levels will always be aligned on the right side, with some consistent spacing
-            # between the title and level.
             padding = max_title_length + 10
             formatted_bites = {
                 _format_bite_key(title, level, padding): slug

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,7 +1,7 @@
 """eatlocal End to End Tests"""
 
 from typer.testing import CliRunner
-from eatlocal.eatlocal import download_bite, Bite
+from eatlocal.eatlocal import download_bite, Bite, _format_bite_key
 from eatlocal.__main__ import cli, EATLOCAL_HOME
 from unittest.mock import patch, mock_open, MagicMock
 from pathlib import Path
@@ -12,6 +12,7 @@ import pytest
 runner = CliRunner()
 
 SUMMING_TEST_BITE = Bite("Sum n numbers", "sum-n-numbers")
+SUMMING_TEST_BITE_LEVEL = "Beginner"
 PARSE_TEST_BITE = Bite("Parse a list of names", "parse-a-list-of-names")
 BAD_CONFIG = {
     "PYBITES_USERNAME": "foo",
@@ -60,7 +61,10 @@ def test_init_command(
 def test_download_command(mock_iterfzf, mock_load_config, testing_config):
     """Test the download command."""
     mock_load_config.return_value = testing_config
-    mock_iterfzf.return_value = SUMMING_TEST_BITE.title
+    formatted_title = _format_bite_key(
+        SUMMING_TEST_BITE.title, SUMMING_TEST_BITE_LEVEL, len(SUMMING_TEST_BITE.title)
+    )
+    mock_iterfzf.return_value = formatted_title
 
     runner.invoke(cli, ["download"])
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -16,6 +16,8 @@ from eatlocal.eatlocal import (
     get_credentials,
     load_config,
     set_local_dir,
+    _unformat_bite_key,
+    _format_bite_key,
 )
 
 NOT_DOWNLOADED = (
@@ -105,11 +107,27 @@ def test_choose_bite(mock_iterfzf, mock_requests):
     api_data = json.load(open("./tests/testing_content/bites_api.json"))
     mock_response.json.return_value = api_data
     mock_requests.return_value = mock_response
-    mock_iterfzf.return_value = SUMMING_TEST_BITE.title
+
+    # Create the formatted title that would be displayed in iterfzf
+    max_title_length = max(len(bite["title"]) for bite in api_data)
+    padding = max_title_length + 10
+    formatted_title = _format_bite_key(
+        SUMMING_TEST_BITE.title,
+        next(
+            bite["level"]
+            for bite in api_data
+            if bite["title"] == SUMMING_TEST_BITE.title
+        ),
+        padding,
+    )
+
+    # Mock iterfzf to return the formatted title
+    mock_iterfzf.return_value = formatted_title
 
     bite = choose_bite()
     assert isinstance(bite, Bite)
-    assert bite.title == SUMMING_TEST_BITE.title
+    # We need to unformat the title to match it with the original
+    assert _unformat_bite_key(bite.title) == SUMMING_TEST_BITE.title
     assert bite.slug == SUMMING_TEST_BITE.slug
 
 


### PR DESCRIPTION
* Added a level column when all bites are downloaded with the `eatlocal download` command

![image](https://github.com/user-attachments/assets/8fb6d0a4-ea48-459c-b208-26ba5b4f4813)

* The level column is not shown on `$ eatlocal download --level <bite level>` since we are already filtering the bites so it would not make sense to have the column. 

![image](https://github.com/user-attachments/assets/56c3fba0-eb86-4b8a-be3c-517afcb200ac)


Closes #64 